### PR TITLE
Add `Batch::pull_waiting_items`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,5 @@
+# Unreleased (0.1.1)
+* Add `Batch::pull_waiting_items`.
+
 # 0.1.0
 * Implement `BatchMutex`.


### PR DESCRIPTION
Add `Batch::pull_waiting_items`

> Takes items that have been submitted after this [Batch](file:///home/alex/.cargo/target/doc/benjamin_batchly/struct.Batch.html) was returned and adds them to this batch to be processed immediately.
> New items are appended onto `Batch::items`.
> Returns true if any new items were pulled in.